### PR TITLE
[Feat] #8 무한 스크롤 기능 구현

### DIFF
--- a/PokemonIndex/View/MainViewController.swift
+++ b/PokemonIndex/View/MainViewController.swift
@@ -22,7 +22,7 @@ final class MainViewController: BaseViewController {
     private let disposebag = DisposeBag()
     
     private var pokemonList = [PokemonList.Pokemon]()
-
+    
     
     private let monsterBallImageView = UIImageView() // 몬스터볼 이미지
     // 포켓몬 리스트 UICollectionView
@@ -30,11 +30,12 @@ final class MainViewController: BaseViewController {
         let layout = UICollectionViewFlowLayout()
         layout.minimumLineSpacing = 4
         layout.minimumInteritemSpacing = 4
-
+        
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.register(PokemonListCell.self, forCellWithReuseIdentifier: String(describing: PokemonListCell.self))
         collectionView.delegate = self
         collectionView.dataSource = self
+        collectionView.alwaysBounceVertical = true // 튕기는 느낌
         return collectionView
     }()
     
@@ -130,5 +131,26 @@ extension MainViewController: UICollectionViewDataSource {
         self.navigationController?.pushViewController(detailVC, animated: true)
         //print(id)
         
+    }
+    
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        guard scrollView.isDragging == true else { return }
+        
+        // 스크롤 y축 위치
+        let offsetY = scrollView.contentOffset.y
+        // 스크롤 뷰 내용의 높이
+        let contentHeight = scrollView.contentSize.height
+        // 스크롤 뷰의 높이 (실제 화면에 보이는 높이)
+        let height = scrollView.frame.size.height
+        
+        let pullUpDistance = offsetY + height - contentHeight
+        let threshold: CGFloat = 100
+        
+        if pullUpDistance > threshold {
+            if !viewModel.isLoading {
+                print("아래로 땅겨서 호출")
+                viewModel.fetchPokemonList()
+            }
+        }
     }
 }

--- a/PokemonIndex/ViewModel/MainViewModel.swift
+++ b/PokemonIndex/ViewModel/MainViewModel.swift
@@ -23,20 +23,28 @@ class MainViewModel {
     /// - 타입은 [PokemonList.Pokemon], 포켓몬 리스트 배열.
     /// - 초기값으로 빈 배열을 설정합니다.
     let pokemonListSubject = BehaviorSubject(value: [PokemonList.Pokemon]())
-    
     private let disposeBag = DisposeBag()
     
-    private let limit = 20
-    private let offset = 0
+    // 현재까지 로드된 포켓몬 배열
+    private var allPokemonList: [PokemonList.Pokemon] = []
+    
+    private let limit = 21
+    private var offset = 0
+    
+    var isLoading = false // 중복 호출 방지
     
     init() {
         fetchPokemonList()
     }
-    
-    
+
     func fetchPokemonList() {
         
+        // 중복 호출 방지
+        guard !isLoading else { return }
+        isLoading = true
+        
         guard let url = URL(string: "https://pokeapi.co/api/v2/pokemon?limit=\(limit)&offset=\(offset)") else {
+            isLoading = false
             return
         }
         
@@ -45,12 +53,24 @@ class MainViewModel {
         // 응답을 BehaviorSubject에 전달
         // View는 pokemonListSubject를 구독하고 있기 때문에 자동으로 반응함
         NetworkManager.shared.fetch(url: url)
+            .delay(.milliseconds(300), scheduler: MainScheduler.instance)
         // 구독, API로 데이터를 가져오면 response.results 을 Subject 로 전달
             .subscribe(onSuccess: { [weak self] (response: PokemonList) in
-                self?.pokemonListSubject.onNext(response.results)
+                guard let self = self else { return }
+                
+                self.offset += self.limit // 다음 페이지 준비
+                
+                // 기존 리스트에 누적
+                self.allPokemonList.append(contentsOf: response.results)
+                // 누적 된 데이터 방출
+                self.pokemonListSubject.onNext(self.allPokemonList)
+                
+                self.isLoading = false // 로딩 상태 해제
+                
                 // 실패 시, Subject에 에러를 담아 View에 전달
             }, onFailure: { [weak self] error in
                 self?.pokemonListSubject.onError(error)
+                self?.isLoading = false
             }).disposed(by: disposeBag)
     }
 }


### PR DESCRIPTION
close #8 
<!-- close #No(이슈 넘버 등록하면 자동으로 이슈가 닫힙니다. 이슈를 닫고 싶지 않다면, 즉 해당 이슈의 작업이 아직 끝나지 않았다면 닫지 않습니다.) -->

## *⛳️ Work Description*
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 무한 스크롤 구현 (difficult 🔥)
- Level 3 에서는 20개의 포켓몬 정보만 불러왔었습니다.
- `limit = 20` 값을 유지한채로, 모든 포켓몬을 볼 때까지 무한히 스크롤 할 수 있는 무한 스크롤을 구현해주세요.

## *📸 Screenshot*
![Simulator Screen Recording - iPhone 16 Pro - 2025-05-16 at 21 06 39](https://github.com/user-attachments/assets/e1c70263-c715-4939-9d8a-ee18379925bc)

<!-- 구현한 부분의 시뮬레이터 스크린샷을 올려주시면 됩니다. -->
<!-- 기기대응을 위해 사이즈가 다른 기기별로 스크린샷을 올리기도 합니다. -->
<!-- 움직이는 동작일 경우, 시뮬레이터 영상을 녹화하고 gif로 저장하여 드래그 앤 드롭을 통해 업로드하면 됩니다. -->

## *📢 To Reviewers*

<!-- 이 PR을 리뷰하는 사람들에게 할 말이 있다면 작성하시면 됩니다. -->
- 코드리뷰 부탁드립니다. 

## *✅ Checklist*

<!-- PR을 올리기 전에 PR을 올리는 대상자가 점검할 내용입니다. -->
- [x] 주석 및 프린트문 제거 확인.
- [x] 컨벤션 준수 확인.
